### PR TITLE
fix: reset vm.memory to reuse vm

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -59,6 +59,7 @@ func (vm *VM) Run(program *Program, env interface{}) (out interface{}, err error
 	}()
 
 	vm.limit = MemoryBudget
+	vm.memory = 0
 	vm.ip = 0
 	vm.pp = 0
 


### PR DESCRIPTION
Currently, `memory` field is not reset when the `vm` is reused, and the value of `memory` will keep increasing if using array operation like `filter`, which makes it eventually exceed the `MemoryBudget` limit.

This commit fixed this issue and allow to reuse `vm` for the programs which contains some specific operations that increase 
 the value of `memory`.